### PR TITLE
Grid Fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -4618,7 +4618,7 @@ Watch Video
         <li><a ><img src="static/images/compressed/gallery/41.jpg"/></a></li>
         <li><a ><img src="static/images/compressed/gallery/42.jpg"/></a></li>
         <li><a ><img src="static/images/compressed/gallery/43.jpg"/></a></li>
-        <li><a ><img src="static/images/compressed/gallery/44.jpg"/></a></l
+        <li><a ><img src="static/images/compressed/gallery/44.jpg"/></a></li> -->
               </ul>
             </div>
           
@@ -6085,7 +6085,7 @@ Watch Video
         maxStep: 2,
         interval: 2000,
         w1024: {
-          rows: 5,
+          rows: 4,
           columns: 6
         },
         w768: {


### PR DESCRIPTION
## Summary
Fixes layout rendering issues in the Gallery section where images overflowed, broke container structure, and left empty trailing gaps on desktop viewports.

## Root Cause
1. **Unclosed HTML Comment Tag:** An invalid syntax (`</l` instead of `-->`) at the end of commented-out gallery items left the `<!--` comment open, accidentally swallowing the closing `</ul>` and `</div>` tags of the `#ri-grid` container.
2. **Grid Capacity Mismatch:** The `gridrotator` configuration for desktop (`w1024`) was set to 5 rows × 6 columns (30 slots), while only 26 images exist in the gallery. This left 4 empty slots on the 5th row and prevented the rotation animation from starting.
## Changes Made
- Fixed the HTML comment syntax in `index.html` (`</li> -->`), restoring proper HTML container closure.
- Adjusted `w1024` grid dimensions in `index.html` from `rows: 5` to `rows: 4` ($4 \times 6 = 24$ visible slots), ensuring a full grid layout without blank spaces.